### PR TITLE
Implement cross-server teleport requests

### DIFF
--- a/src/main/java/com/liuchangking/dreamtpa/DreamTPA.java
+++ b/src/main/java/com/liuchangking/dreamtpa/DreamTPA.java
@@ -1,17 +1,64 @@
 package com.liuchangking.dreamtpa;
 
+import com.liuchangking.dreamtpa.command.TpaCommand;
+import com.liuchangking.dreamtpa.command.TpAcceptCommand;
+import com.liuchangking.dreamtpa.command.TpDenyCommand;
+import com.liuchangking.dreamtpa.listener.RequestListener;
+import com.liuchangking.dreamtpa.request.TeleportRequest;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
+/**
+ * 跨服传送请求的主插件类
+ */
 public final class DreamTPA extends JavaPlugin {
+
+    private final Map<UUID, TeleportRequest> requestsByRequester = new HashMap<>();
+    private final Map<String, TeleportRequest> requestsByTarget = new HashMap<>();
+    private int expireSeconds;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        this.expireSeconds = getConfig().getInt("request-expire-seconds", 120);
 
+        TpaCommand tpaCommand = new TpaCommand(this);
+        getCommand("dreamtpa").setExecutor(tpaCommand);
+        getCommand("dreamtpa").setTabCompleter(tpaCommand);
+        getCommand("tpaccept").setExecutor(new TpAcceptCommand(this));
+        getCommand("tpdeny").setExecutor(new TpDenyCommand(this));
+
+        Bukkit.getPluginManager().registerEvents(new RequestListener(this), this);
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        // 插件关闭时的处理逻辑
+    }
+
+    public int getExpireSeconds() {
+        return expireSeconds;
+    }
+
+    public void addRequest(TeleportRequest request) {
+        requestsByRequester.put(request.getRequester().getUniqueId(), request);
+        requestsByTarget.put(request.getTargetName().toLowerCase(), request);
+    }
+
+    public TeleportRequest getRequestByRequester(UUID uuid) {
+        return requestsByRequester.get(uuid);
+    }
+
+    public TeleportRequest getRequestByTarget(String name) {
+        return requestsByTarget.get(name.toLowerCase());
+    }
+
+    public void removeRequest(TeleportRequest request) {
+        requestsByRequester.remove(request.getRequester().getUniqueId());
+        requestsByTarget.remove(request.getTargetName().toLowerCase());
     }
 }

--- a/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
@@ -1,0 +1,41 @@
+package com.liuchangking.dreamtpa.command;
+
+import com.liuchangking.dreamtpa.DreamTPA;
+import com.liuchangking.dreamtpa.request.TeleportRequest;
+import com.liuchangking.dreamengine.api.DreamServerAPI;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * 处理同意传送请求的命令
+ */
+public class TpAcceptCommand implements CommandExecutor {
+
+    private final DreamTPA plugin;
+
+    public TpAcceptCommand(DreamTPA plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("只有玩家可以使用该命令");
+            return true;
+        }
+        Player target = (Player) sender;
+        TeleportRequest request = plugin.getRequestByTarget(target.getName());
+        if (request == null) {
+            target.sendMessage("没有待处理的传送请求");
+            return true;
+        }
+        plugin.removeRequest(request);
+        String serverId = DreamServerAPI.getPlayerServerId(target.getName());
+        DreamServerAPI.sendPlayerToServer(request.getRequester(), serverId);
+        request.getRequester().sendMessage("正在传送到 " + target.getName());
+        target.sendMessage("你接受了 " + request.getRequester().getName() + " 的传送请求");
+        return true;
+    }
+}

--- a/src/main/java/com/liuchangking/dreamtpa/command/TpDenyCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpDenyCommand.java
@@ -1,0 +1,38 @@
+package com.liuchangking.dreamtpa.command;
+
+import com.liuchangking.dreamtpa.DreamTPA;
+import com.liuchangking.dreamtpa.request.TeleportRequest;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * 处理拒绝传送请求的命令
+ */
+public class TpDenyCommand implements CommandExecutor {
+
+    private final DreamTPA plugin;
+
+    public TpDenyCommand(DreamTPA plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("只有玩家可以使用该命令");
+            return true;
+        }
+        Player target = (Player) sender;
+        TeleportRequest request = plugin.getRequestByTarget(target.getName());
+        if (request == null) {
+            target.sendMessage("没有待处理的传送请求");
+            return true;
+        }
+        plugin.removeRequest(request);
+        target.sendMessage("你拒绝了 " + request.getRequester().getName() + " 的传送请求");
+        request.getRequester().sendMessage(target.getName() + " 拒绝了你的传送请求");
+        return true;
+    }
+}

--- a/src/main/java/com/liuchangking/dreamtpa/command/TpaCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpaCommand.java
@@ -1,0 +1,80 @@
+package com.liuchangking.dreamtpa.command;
+
+import com.liuchangking.dreamtpa.DreamTPA;
+import com.liuchangking.dreamtpa.request.TeleportRequest;
+import com.liuchangking.dreamengine.api.DreamServerAPI;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+/**
+ * 处理 /tpa 和 /dreamtpa 命令
+ */
+public class TpaCommand implements CommandExecutor, TabCompleter {
+
+    private final DreamTPA plugin;
+
+    public TpaCommand(DreamTPA plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("只有玩家可以使用该命令");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (args.length != 1) {
+            player.sendMessage("用法: /tpa <玩家>");
+            return true;
+        }
+        String targetName = args[0];
+        if (player.getName().equalsIgnoreCase(targetName)) {
+            player.sendMessage("你不能向自己发送请求");
+            return true;
+        }
+        if (!DreamServerAPI.isPlayerOnline(targetName)) {
+            player.sendMessage("该玩家不在线");
+            return true;
+        }
+        if (plugin.getRequestByRequester(player.getUniqueId()) != null) {
+            player.sendMessage("你已有未完成的传送请求");
+            return true;
+        }
+        TeleportRequest request = new TeleportRequest(player, targetName);
+        plugin.addRequest(request);
+        player.sendMessage("已向 " + targetName + " 发送传送请求, 请在" + plugin.getExpireSeconds() + "秒内保持不动");
+        Player targetPlayer = Bukkit.getPlayerExact(targetName);
+        if (targetPlayer != null) {
+            targetPlayer.sendMessage(player.getName() + " 请求传送到你这里, 输入 /tpaccept 同意或 /tpdeny 拒绝");
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (plugin.getRequestByTarget(targetName) == request) {
+                plugin.removeRequest(request);
+                player.sendMessage("传送请求已过期");
+                if (targetPlayer != null && targetPlayer.isOnline()) {
+                    targetPlayer.sendMessage("来自 " + player.getName() + " 的传送请求已过期");
+                }
+            }
+        }, plugin.getExpireSeconds() * 20L);
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            String prefix = args[0].toLowerCase();
+            return DreamServerAPI.getClusterPlayers().stream()
+                .filter(name -> name.toLowerCase().startsWith(prefix))
+                .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/liuchangking/dreamtpa/listener/RequestListener.java
+++ b/src/main/java/com/liuchangking/dreamtpa/listener/RequestListener.java
@@ -1,0 +1,40 @@
+package com.liuchangking.dreamtpa.listener;
+
+import com.liuchangking.dreamtpa.DreamTPA;
+import com.liuchangking.dreamtpa.request.TeleportRequest;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+/**
+ * 当请求方移动时取消传送请求
+ */
+public class RequestListener implements Listener {
+
+    private final DreamTPA plugin;
+
+    public RequestListener(DreamTPA plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        TeleportRequest request = plugin.getRequestByRequester(player.getUniqueId());
+        if (request == null) {
+            return;
+        }
+        if (event.getFrom().getBlockX() != event.getTo().getBlockX() ||
+            event.getFrom().getBlockY() != event.getTo().getBlockY() ||
+            event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+            plugin.removeRequest(request);
+            player.sendMessage("你移动了, 传送请求已取消");
+            Player target = Bukkit.getPlayerExact(request.getTargetName());
+            if (target != null) {
+                target.sendMessage(player.getName() + " 取消了传送请求");
+            }
+        }
+    }
+}

--- a/src/main/java/com/liuchangking/dreamtpa/request/TeleportRequest.java
+++ b/src/main/java/com/liuchangking/dreamtpa/request/TeleportRequest.java
@@ -1,0 +1,31 @@
+package com.liuchangking.dreamtpa.request;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * 储存待处理传送请求的数据
+ */
+public class TeleportRequest {
+    private final Player requester;
+    private final String targetName;
+    private final Location origin;
+
+    public TeleportRequest(Player requester, String targetName) {
+        this.requester = requester;
+        this.targetName = targetName;
+        this.origin = requester.getLocation().clone();
+    }
+
+    public Player getRequester() {
+        return requester;
+    }
+
+    public String getTargetName() {
+        return targetName;
+    }
+
+    public Location getOrigin() {
+        return origin;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,2 @@
+# 传送请求的有效时间(秒)
+request-expire-seconds: 120

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,11 @@ version: '${version}'
 main: com.liuchangking.dreamtpa.DreamTPA
 depend: [DreamEngine]
 api-version: 1.18
+commands:
+  dreamtpa:
+    description: 发送传送请求
+    aliases: [tpa]
+  tpaccept:
+    description: 同意传送请求
+  tpdeny:
+    description: 拒绝传送请求


### PR DESCRIPTION
## Summary
- restore Gradle wrapper to 7.3.3
- organize commands, listener, and request model into dedicated packages
- localize plugin, command, listener, and request class comments to Chinese

## Testing
- `bash gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f16d67e0832993d4a2c678df2570