### PR TITLE
修复跨服tpaccept和tpdeny失败的问题

### DIFF
--- a/src/main/java/com/liuchangking/dreamtpa/DreamTPA.java
+++ b/src/main/java/com/liuchangking/dreamtpa/DreamTPA.java
@@ -5,6 +5,8 @@ import com.liuchangking.dreamtpa.command.TpAcceptCommand;
 import com.liuchangking.dreamtpa.command.TpDenyCommand;
 import com.liuchangking.dreamtpa.listener.RequestListener;
 import com.liuchangking.dreamtpa.request.TeleportRequest;
+import com.liuchangking.dreamengine.api.DreamServerAPI;
+import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import java.util.HashMap;
@@ -14,11 +16,12 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.PluginMessageListener;
 
 /**
  * 跨服传送请求的主插件类
  */
-public final class DreamTPA extends JavaPlugin {
+public final class DreamTPA extends JavaPlugin implements PluginMessageListener {
 
     private final Map<UUID, TeleportRequest> requestsByRequester = new HashMap<>();
     private final Map<String, TeleportRequest> requestsByTarget = new HashMap<>();
@@ -29,6 +32,7 @@ public final class DreamTPA extends JavaPlugin {
         saveDefaultConfig();
         this.expireSeconds = getConfig().getInt("request-expire-seconds", 120);
         Bukkit.getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
+        Bukkit.getMessenger().registerIncomingPluginChannel(this, "dream:tpa", this);
 
         TpaCommand tpaCommand = new TpaCommand(this);
         getCommand("dreamtpa").setExecutor(tpaCommand);
@@ -72,5 +76,49 @@ public final class DreamTPA extends JavaPlugin {
         out.writeUTF(target);
         out.writeUTF(message);
         from.sendPluginMessage(this, "BungeeCord", out.toByteArray());
+    }
+
+    public void forwardCommand(Player sender, String subChannel) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF("Forward");
+        out.writeUTF("ALL");
+        out.writeUTF("dream:tpa");
+        ByteArrayDataOutput msg = ByteStreams.newDataOutput();
+        msg.writeUTF(subChannel);
+        msg.writeUTF(sender.getName());
+        out.writeShort(msg.toByteArray().length);
+        out.write(msg.toByteArray());
+        sender.sendPluginMessage(this, "BungeeCord", out.toByteArray());
+    }
+
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+        if (!channel.equals("dream:tpa")) {
+            return;
+        }
+        ByteArrayDataInput in = ByteStreams.newDataInput(message);
+        String sub = in.readUTF();
+        String targetName = in.readUTF();
+        if ("TpAccept".equalsIgnoreCase(sub)) {
+            TeleportRequest request = getRequestByTarget(targetName);
+            if (request == null) {
+                return;
+            }
+            removeRequest(request);
+            String targetServerId = DreamServerAPI.getPlayerServerId(targetName);
+            DreamServerAPI.sendPlayerToServer(request.getRequester(), targetServerId);
+            request.getRequester().sendMessage("正在传送到 " + targetName);
+            sendMessageCrossServer(request.getRequester(), targetName,
+                "你接受了 " + request.getRequester().getName() + " 的传送请求");
+        } else if ("TpDeny".equalsIgnoreCase(sub)) {
+            TeleportRequest request = getRequestByTarget(targetName);
+            if (request == null) {
+                return;
+            }
+            removeRequest(request);
+            request.getRequester().sendMessage(targetName + " 拒绝了你的传送请求");
+            sendMessageCrossServer(request.getRequester(), targetName,
+                "你拒绝了 " + request.getRequester().getName() + " 的传送请求");
+        }
     }
 }

--- a/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
@@ -28,7 +28,7 @@ public class TpAcceptCommand implements CommandExecutor {
         Player target = (Player) sender;
         TeleportRequest request = plugin.getRequestByTarget(target.getName());
         if (request == null) {
-            target.sendMessage("没有待处理的传送请求");
+            plugin.forwardCommand(target, "TpAccept");
             return true;
         }
         plugin.removeRequest(request);

--- a/src/main/java/com/liuchangking/dreamtpa/command/TpDenyCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpDenyCommand.java
@@ -27,7 +27,7 @@ public class TpDenyCommand implements CommandExecutor {
         Player target = (Player) sender;
         TeleportRequest request = plugin.getRequestByTarget(target.getName());
         if (request == null) {
-            target.sendMessage("没有待处理的传送请求");
+            plugin.forwardCommand(target, "TpDeny");
             return true;
         }
         plugin.removeRequest(request);


### PR DESCRIPTION
## Summary
- 通过 BungeeCord 渠道转发 /tpaccept 与 /tpdeny 以支持跨服处理
- 新增插件消息监听器, 同步请求处理并跨服通知双方

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a4411c306c8329841ded4582eb6db3