### PR TITLE
feat: allow accepting latest or specific teleport request

### DIFF
--- a/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
@@ -26,10 +26,20 @@ public class TpAcceptCommand implements CommandExecutor {
             return true;
         }
         Player target = (Player) sender;
-        TeleportRequest request = plugin.getRequestByTarget(target.getName());
-        if (request == null) {
-            plugin.forwardCommand(target, "TpAccept");
-            return true;
+        TeleportRequest request;
+        if (args.length >= 1) {
+            String requesterName = args[0];
+            request = plugin.getRequestByTarget(target.getName(), requesterName);
+            if (request == null) {
+                plugin.forwardCommand(target, "TpAccept", requesterName);
+                return true;
+            }
+        } else {
+            request = plugin.getRequestByTarget(target.getName());
+            if (request == null) {
+                plugin.forwardCommand(target, "TpAccept");
+                return true;
+            }
         }
         plugin.removeRequest(request);
         String targetServerId = DreamServerAPI.getPlayerServerId(target.getName());

--- a/src/main/java/com/liuchangking/dreamtpa/command/TpaCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpaCommand.java
@@ -67,7 +67,7 @@ public class TpaCommand implements CommandExecutor, TabCompleter {
                 player.getName() + " 请求传送到你这里, 输入 /tpaccept 同意或 /tpdeny 拒绝");
         }
         Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            if (plugin.getRequestByTarget(targetName) == request) {
+            if (plugin.hasRequest(request)) {
                 plugin.removeRequest(request);
                 player.sendMessage("传送请求已过期");
                 if (targetPlayer != null && targetPlayer.isOnline()) {


### PR DESCRIPTION
## Summary
- keep multiple pending requests per player and track them by arrival order
- `tpaccept` accepts the newest request by default or a named requester when specified
- support forwarding optional requester names for cross-server acceptance/denial

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a449279fc083298f40af838b90c30a