### PR TITLE
Use Redis for cross-server messaging and improve tpaccept tab completion

### DIFF
--- a/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpAcceptCommand.java
@@ -3,15 +3,19 @@ package com.liuchangking.dreamtpa.command;
 import com.liuchangking.dreamtpa.DreamTPA;
 import com.liuchangking.dreamtpa.request.TeleportRequest;
 import com.liuchangking.dreamengine.api.DreamServerAPI;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
 /**
  * 处理同意传送请求的命令
  */
-public class TpAcceptCommand implements CommandExecutor {
+public class TpAcceptCommand implements CommandExecutor, TabCompleter {
 
     private final DreamTPA plugin;
 
@@ -52,5 +56,17 @@ public class TpAcceptCommand implements CommandExecutor {
         request.getRequester().sendMessage("正在传送到 " + target.getName());
         target.sendMessage("你接受了 " + request.getRequester().getName() + " 的传送请求");
         return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1 && sender instanceof Player) {
+            String prefix = args[0].toLowerCase();
+            List<String> requesters = plugin.getRequesters(((Player) sender).getName());
+            return requesters.stream()
+                .filter(name -> name.toLowerCase().startsWith(prefix))
+                .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
## Summary
- Replace BungeeCord plugin messaging with Redis pub/sub for cross-server communication
- Offer `/tpaccept` tab completion from players who sent requests
- Disable DreamTPA when Redis is not initialized at startup

## Testing
- `sh gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a467cc68e48329bbbf75618639c47e