### PR TITLE
Fix cross-server teleport location and tpaccept tab completion

### DIFF
--- a/src/main/java/com/liuchangking/dreamtpa/command/TpaCommand.java
+++ b/src/main/java/com/liuchangking/dreamtpa/command/TpaCommand.java
@@ -58,6 +58,7 @@ public class TpaCommand implements CommandExecutor, TabCompleter {
         }
         TeleportRequest request = new TeleportRequest(player, targetName);
         plugin.addRequest(request);
+        plugin.notifyRequestAdd(targetName, player.getName());
         player.sendMessage("已向 " + targetName + " 发送传送请求, 请在" + plugin.getExpireSeconds() + "秒内保持不动");
         final Player targetPlayer = Bukkit.getPlayerExact(targetName);
         if (targetPlayer != null) {

--- a/src/main/java/com/liuchangking/dreamtpa/listener/TeleportListener.java
+++ b/src/main/java/com/liuchangking/dreamtpa/listener/TeleportListener.java
@@ -1,0 +1,30 @@
+package com.liuchangking.dreamtpa.listener;
+
+import com.liuchangking.dreamtpa.DreamTPA;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+/**
+ * 处理跨服传送后的定位
+ */
+public class TeleportListener implements Listener {
+
+    private final DreamTPA plugin;
+
+    public TeleportListener(DreamTPA plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        Location loc = plugin.pollPendingTeleport(player.getName());
+        if (loc != null) {
+            Bukkit.getScheduler().runTask(plugin, () -> player.teleport(loc));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track pending teleports and remote requests via Redis to support cross-server tpa
- teleport players to the proper location after switching servers
- include cross-server requesters in `/tpaccept` tab completion

## Testing
- `bash gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a47358339483299a2491f1e92e55b4